### PR TITLE
add app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,6 +4,7 @@
   "summary": "Roots is a toolkit built on best practices for advanced front-end web development. It includes a mature static site compiler including layouts, partials, dynamic content, precompiled javascript templates, and diverse language and plugin support. It also includes an extensive css helper library for stylus. Fun fact — this very website was built with roots!",
   "keywords": ["roots", "carrot", "static"],
   "website": "http://roots.cx",
+  "repository": "https://github.com/zeke/roots-buildpack-sample",
   "logo": "http://roots.cx/img/circle-logo.svg",
   "success_url": "http://roots.cx/docs/",
   "env": {

--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name": "roots",
+  "name": "Roots",
   "description": "A Heroku-ready static site generator from Carrot Creative.",
   "summary": "Roots is a toolkit built on best practices for advanced front-end web development. It includes a mature static site compiler including layouts, partials, dynamic content, precompiled javascript templates, and diverse language and plugin support. It also includes an extensive css helper library for stylus. Fun fact — this very website was built with roots!",
   "keywords": ["roots", "carrot", "static"],

--- a/app.json
+++ b/app.json
@@ -1,0 +1,13 @@
+{
+  "name": "roots-sample",
+  "description": "A Heroku-ready roots template from Carrot Creative.",
+  "keywords": ["roots", "carrot", "static"],
+  "urls": {
+    "website": "http://roots.cx",
+    "logo": "http://roots.cx/img/circle-logo.svg",
+    "success": "/getting-started"
+  },
+  "env": {
+    "BUILDPACK_URL": "https://github.com/carrot/roots-buildpack"
+  }
+}

--- a/app.json
+++ b/app.json
@@ -1,12 +1,11 @@
 {
-  "name": "roots-sample",
-  "description": "A Heroku-ready roots template from Carrot Creative.",
+  "name": "roots",
+  "description": "A Heroku-ready static site generator from Carrot Creative.",
+  "summary": "Roots is a toolkit built on best practices for advanced front-end web development. It includes a mature static site compiler including layouts, partials, dynamic content, precompiled javascript templates, and diverse language and plugin support. It also includes an extensive css helper library for stylus. Fun fact — this very website was built with roots!",
   "keywords": ["roots", "carrot", "static"],
-  "urls": {
-    "website": "http://roots.cx",
-    "logo": "http://roots.cx/img/circle-logo.svg",
-    "success": "/getting-started"
-  },
+  "website": "http://roots.cx",
+  "logo": "http://roots.cx/img/circle-logo.svg",
+  "success_url": "http://roots.cx/docs/",
   "env": {
     "BUILDPACK_URL": "https://github.com/carrot/roots-buildpack"
   }


### PR DESCRIPTION
I still don't have this thing running locally, but the `app.json` manifest is working!

Eventually support for this will make its way into the Heroku CLI and will also be honored on first push with a regular old `git push heroku master`, but for now you have to use the nascent Heroku Build API. Here's the current rough-around-the-edges way to spawn a new app with a bash function:

``` sh
$ concoct zeke/roots-buildpack-sample
```

``` sh
concoct() {
  host="https://nyata.herokuapp.com"
  tarball_url="https://codeload.github.com/${1}/legacy.tar.gz/master"
  token=$(heroku auth:token)

  echo "\nConcocting..."
  echo $tarball_url

  api_response=$(curl \
    -u :$token \
    -X POST \
    --silent \
    -H 'Content-Type: application/json' \
    -d "{ \"source_blob\": { \"url\": \"$tarball_url\" } }" \
    $host/builds)

  echo "\nAPI Response"
  echo $api_response

  echo "\nBuild ID"
  build_id=$(echo $api_response | jq -r .id)
  echo $build_id

  echo "\nBuild Status URL"
  status_url="$host/builds/$build_id"
  echo $status_url

  # status is a reserved word in bash
  state="pending"
  while [ $state == "pending" ]; do
    status_response=$(curl \
      -u :$token \
      --silent \
      -H 'Content-Type: application/json' \
      $status_url)
    state=$(echo $status_response | jq -r .status)
    echo "\nStatus"
    echo $status_response
    sleep 1
  done
}
```
